### PR TITLE
一些优化调整

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ use to get malloc and free backtrace, include dmabuffer by hook `ioctl` and `clo
   ```
   - DUMP_PEAK_VALUE_MB 的单位默认为 MB
 
+* 抓取峰值步骤
+  - 利用 cheakpoint 机制执行两次程序，并对两次的内存调用堆栈输出进行对比，分析内存调用的增量，此时的内存调用是以时间排序，可以从后向前对比
+  ``` c++
+    void test() {
+      ....
+    }
+
+    int main() {
+       for (int i = 0; i < 2; ++i) {
+        test();
+        kill(getpid(), 33);
+       }
+    }
+
+  ```
+
 * 配置参数意义
   - `backtrace_dump_on_exit_`: 程序退出时，打印堆栈
   - `backtrace_frames_`: 抓取堆栈的最大深度，默认 128

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ use to get malloc and free backtrace, include dmabuffer by hook `ioctl` and `clo
   ```
   - 然后，根据 total peak used 的值，通过环境变量 `DUMP_PEAK_VALUE_MB` 设置 backtrace_dump_peak_val_ 的值，通常要小于 total peak used 50MB 左右，设置方式如下
   ```
-  export DUMP_PEAK_VALUE_MB = xxx
+  export DUMP_PEAK_VALUE_MB=xxx
 
   或者
 

--- a/backtrace/include/memory_hook.h
+++ b/backtrace/include/memory_hook.h
@@ -13,3 +13,6 @@ extern int (*m_sys_close)(int fd);
 extern void* (*m_sys_mmap)(
         void* addr, size_t size, int prot, int flags, int fd, off_t offset);
 extern int (*m_sys_munmap)(void* addr, size_t size);
+
+
+void init_hook();

--- a/backtrace/src/Config.cpp
+++ b/backtrace/src/Config.cpp
@@ -1,5 +1,6 @@
 #include <bionic/reserved_signals.h>
 #include <cassert>
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -13,9 +14,33 @@ static constexpr const char DEFAULT_BACKTRACE_DUMP_PREFIX[] =
 static bool ParseValue(const char* value, size_t* parsed_value) {
     *parsed_value = 0;
     if (value == nullptr) {
+        printf("Not Set DUMP_PEAK_VALUE_MB\n");
         return false;
     }
-    *parsed_value = static_cast<size_t>(atol(value)) * 1024 * 1024;
+    // Parse the value into a size_t value.
+    errno = 0;
+    char* end;
+    long long_value = strtol(value, &end, 10);
+    if (errno != 0) {
+        printf("Error DUMP_PEAK_VALUE_MB:%s:%s\n", value, strerror(errno));
+        return false;
+    }
+    if (end == value) {
+        printf("Error DUMP_PEAK_VALUE_MB:%s\n", value);
+        return false;
+    }
+    // 指针值相减
+    if (static_cast<size_t>(end - value) != strlen(value)) {
+        printf("Error DUMP_PEAK_VALUE_MB:%s\n", value);
+        return false;
+    }
+    if (long_value < 0) {
+        printf("Error DUMP_PEAK_VALUE_MB:%s\n", value);
+        return false;
+    }
+
+    printf("DUMP_PEAK_VALUE_MB:%zuMB\n", long_value);
+    *parsed_value = static_cast<size_t>(long_value) * 1024 * 1024;
     return true;
 }
 

--- a/backtrace/src/Config.cpp
+++ b/backtrace/src/Config.cpp
@@ -46,7 +46,7 @@ static bool ParseValue(const char* value, size_t* parsed_value) {
 
 bool Config::Init() {
     // 退出时输出 trace
-    backtrace_dump_on_exit_ = true;
+    backtrace_dump_on_exit_ = false;
     backtrace_frames_ = DEFAULT_BACKTRACE_FRAMES;
     backtrace_dump_prefix_ = DEFAULT_BACKTRACE_DUMP_PREFIX;
 
@@ -65,6 +65,7 @@ bool Config::Init() {
         // 记录峰值
         options_ |= RECORD_MEMORY_PEAK;
         backtrace_min_size_bytes_ = 1024;
+        backtrace_dump_on_exit_ = true;
     }
 
     // 通过信号插入 check point

--- a/backtrace/src/malloc_debug.cpp
+++ b/backtrace/src/malloc_debug.cpp
@@ -1,12 +1,8 @@
-#include <dlfcn.h>
-#include <fcntl.h>
 #include <linux/dma-heap.h>
 #include <signal.h>
 #include <sys/mman.h>
 #include <sys/param.h>  // powerof2 ---> ((((x) - 1) & (x)) == 0)
 #include <unistd.h>
-#include <cstdio>
-#include <cstdlib>
 
 #include <android-base/stringprintf.h>
 
@@ -51,35 +47,6 @@ static void singal_dump_heap(int) {
 }
 
 bool debug_initialize(void* init_space[]) {
-#ifdef __OHOS__
-    void* handle = dlopen("libc.so", RTLD_LAZY);
-    if (!handle) {
-        abort();
-    }
-#else
-    void* handle = RTLD_NEXT;
-#endif
-
-#define RESOLVE(name)                                                  \
-    do {                                                               \
-        auto addr = dlsym(handle, #name);                              \
-        if (!addr) {                                                   \
-            abort();                                                   \
-        }                                                              \
-        m_sys_##name = reinterpret_cast<decltype(m_sys_##name)>(addr); \
-    } while (0)
-    RESOLVE(malloc);
-    RESOLVE(free);
-    RESOLVE(calloc);
-    RESOLVE(realloc);
-    RESOLVE(memalign);
-    RESOLVE(posix_memalign);
-    RESOLVE(ioctl);
-    RESOLVE(close);
-    RESOLVE(mmap);
-    RESOLVE(munmap);
-#undef RESOLVE
-
     if (!DebugDisableInitialize()) {
         return false;
     }

--- a/backtrace/src/memory_hook.cpp
+++ b/backtrace/src/memory_hook.cpp
@@ -1,3 +1,7 @@
+#include <fcntl.h>
+#include <dlfcn.h>
+#include <cstdlib>
+
 #include "memory_hook.h"
 
 void* (*m_sys_malloc)(size_t) = nullptr;
@@ -11,3 +15,35 @@ int (*m_sys_close)(int fd) = nullptr;
 void* (*m_sys_mmap)(
         void* addr, size_t size, int prot, int flags, int fd, off_t offset) = nullptr;
 int (*m_sys_munmap)(void* addr, size_t size) = nullptr;
+
+
+void init_hook() {
+#ifdef __OHOS__
+        void* handle = dlopen("libc.so", RTLD_LAZY);
+        if (!handle) {
+            abort();
+        }
+#else
+        void* handle = RTLD_NEXT;
+#endif
+
+#define RESOLVE(name)                                                      \
+        do {                                                               \
+            auto addr = dlsym(handle, #name);                              \
+            if (!addr) {                                                   \
+                abort();                                                   \
+            }                                                              \
+            m_sys_##name = reinterpret_cast<decltype(m_sys_##name)>(addr); \
+        } while (0)
+        RESOLVE(malloc);
+        RESOLVE(free);
+        RESOLVE(calloc);
+        RESOLVE(realloc);
+        RESOLVE(memalign);
+        RESOLVE(posix_memalign);
+        RESOLVE(ioctl);
+        RESOLVE(close);
+        RESOLVE(mmap);
+        RESOLVE(munmap);
+#undef RESOLVE
+}


### PR DESCRIPTION
1. debug initilization 时可以使用内存申请
2. 增加 DUMP_PEAK_VALUE_MB 错误使用时的报错提示
3. 增加 README 关于内存泄露统计的相关描述
4. 分割 hook 函数的 init 和 debug initialize 的功能
5. 程序退出时默认不再输出堆栈信息，只能通过 checkpoint 或 峰值机制输出堆栈