### PR TITLE
fix MTK platform view dma memory bug for ioctl

### DIFF
--- a/backtrace/CMakeLists.txt
+++ b/backtrace/CMakeLists.txt
@@ -6,3 +6,6 @@ target_include_directories(helper PUBLIC
                             ${CMAKE_CURRENT_SOURCE_DIR}/include
                         )
 target_link_libraries(helper unwindstack)
+if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+    target_compile_options(helper PRIVATE -fno-c++-static-destructors)
+endif ()


### PR DESCRIPTION
修复 MTK 平台上，因为释放顺序问题，导致的 debug_ioctl 中 unordered_set 报错